### PR TITLE
Move ZenIP-42200 from Proposed to Final

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Unless otherwise stated in this repository’s individual files, the contents of
 | Number | Draft Added | Title         | Owner       | Type    | Status |
 | -----: | ----------: | ------------- | ----------- | ------- | ------ |
 | 42000  |  2019-09-27 | ZenIP Process | Jonas Rubel | Process | Draft  |
+| 42200  |  2021-08-12 | Cross-Chain Transfer Protocol | Alberto Garoffolo | Consensus | Final  |

--- a/zenip-42200.md
+++ b/zenip-42200.md
@@ -4,7 +4,7 @@
     ZenIP: 42200
     Title: Cross-Chain Transfer Protocol
     Owners: Alberto Garoffolo, <alberto@zensystem.io>
-    Status: Proposed
+    Status: Final
     Type: Consensus
     Created: 2021-08-12
     License: MIT


### PR DESCRIPTION
The specification on status changes in https://github.com/HorizenOfficial/ZenIPs/blob/master/zenip-42000.md#status-changes is not followed in this case as this ZenIP has been active on the mainchain since December 2021.

This should not serve as a precedent for future ZenIPs, it is being done so that the status of the ZenIP repository reflects the current state of the blockchain as quickly as possible.