### PR TITLE
Move ZenIP-42201 from Draft to Final

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Unless otherwise stated in this repository’s individual files, the contents of
 | Number | Draft Added | Title         | Owner       | Type    | Status |
 | -----: | ----------: | ------------- | ----------- | ------- | ------ |
 | 42000  |  2019-09-27 | ZenIP Process | Jonas Rubel | Process | Draft  |
+| 42200  |  2021-08-12 | Cross-Chain Transfer Protocol | Alberto Garoffolo | Consensus | Final  |

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ Unless otherwise stated in this repository’s individual files, the contents of
 | -----: | ----------: | ------------- | ----------- | ------- | ------ |
 | 42000  |  2019-09-27 | ZenIP Process | Jonas Rubel | Process | Draft  |
 | 42200  |  2021-08-12 | Cross-Chain Transfer Protocol | Alberto Garoffolo | Consensus | Final  |
+| 42201  |  2022-04-07 | Sidechain Versions | Paolo Tagliaferri | Consensus | Final  |

--- a/zenip-42200.md
+++ b/zenip-42200.md
@@ -4,7 +4,7 @@
     ZenIP: 42200
     Title: Cross-Chain Transfer Protocol
     Owners: Alberto Garoffolo, <alberto@zensystem.io>
-    Status: Proposed
+    Status: Final
     Type: Consensus
     Created: 2021-08-12
     License: MIT

--- a/zenip-42201.md
+++ b/zenip-42201.md
@@ -6,7 +6,7 @@
     Owner: Paolo Tagliaferri, <paolotagliaferri@horizenlabs.io>; cronic, <cronic@horizenlabs.io>
     Discussions-To: Paolo Tagliaferri, <paolotagliaferri@horizenlabs.io>
     Comments-URI: https://horizen.global/invite/discord
-    Status: Draft 
+    Status: Final
     Type: Consensus
     Created: 2022-04-07
     License: MIT
@@ -61,8 +61,8 @@ As shown above, the first (most significant byte) of the `withdrawalEpochLength`
 The Mainnet coinbase vout addresses will change at block **#1127000**:
 |Type |From|To|
 |---|---|---|
-|Treasury|zszpcLB6C5B8QvfDbF2dYWXsrpac5DL9WRk |zshX5BAgUvNgM1VoBVKZyFVVozTDjjJvRxJ| 
-|Secure Nodes|zsxWnyDbU8pk2Vp98Uvkx5Nh33RFzqnCpWN |zsx68qSKMNoc1ZPQpGwNFZXVzgf27KN6a9u| 
+|Treasury|zszpcLB6C5B8QvfDbF2dYWXsrpac5DL9WRk |zshX5BAgUvNgM1VoBVKZyFVVozTDjjJvRxJ|
+|Secure Nodes|zsxWnyDbU8pk2Vp98Uvkx5Nh33RFzqnCpWN |zsx68qSKMNoc1ZPQpGwNFZXVzgf27KN6a9u|
 |Super Nodes|zsnL6pKdzvZ1BPVzALUoqw2KsY966XFs5CE |zszMgcogAqz49sLHGV22YCDFSvwzwkfog4k|
 
 Reward percentages will stay unchanged.
@@ -71,7 +71,6 @@ Reward percentages will stay unchanged.
 **Block Template Request Extensions**
 
 The `getblocktemplate` method includes two additional return values, based on the optional parameter `roots`:
- 
 | Key | Required | Type | Description |
 |---|---|---|---|
 | merkleTree | no  | string  | Merkle root of the tree containing transactions and certificates of the current block |


### PR DESCRIPTION
The specification on status changes in https://github.com/HorizenOfficial/ZenIPs/blob/master/zenip-42000.md#status-changes is not followed in this case as this ZenIP has been active on the mainchain since April 2022.

This should not serve as a precedent for future ZenIPs, it is being done so that the status of the ZenIP repository reflects the current state of the blockchain as quickly as possible.