### PR TITLE
Update zenip-42000.md

### DIFF
--- a/zenip-42000.md
+++ b/zenip-42000.md
@@ -193,14 +193,14 @@ Please send all ZenIP-related communications either by email to
 
 The current ZenIP Editors are:
 
-- Peter Stewart, representing the Horizen Community Council
+- Gustavo Fialho and Pier Stabilini, representing the Horizen Community Council
 - Rosario Pabst, representing the Zen Blockchain Foundation
-- Maurizio Binello, representing the Horizen Labs Company
+- Zain Cheng, representing the Horizen Labs Company
 
 Each organization has its own process for assigning its representative
 editor. All can be reached at <ZenIPs@horizen.global>.
 
-ZenIP Editors will have to make a number of decision and unanimity cannot be assumed and is not necessary for all kinds of decisions.
+ZenIP Editors will have to make a number of decisions and unanimity cannot be assumed and is not necessary for all kinds of decisions. If an organization has more than one Editor, a single editor should represent the organization on each decision such that there are three Editors voting on each proposal.
 When we say *majority decision* this means more than half (>50%) of the Editors need to agree.
 When we say *supermajority decision* this means more than two thirds (>66.6%) need to agree.
 Additionally, there are decisions that require *unanimity*.
@@ -214,7 +214,8 @@ contribute to the ZenIP process involved as Editors. New Editors must be confirm
 unanimously by all existing Editors.
 
 Removing a ZenIP Editor must similarly be agreed upon unanimously by all Editors
-except for the Editor in question.
+except for the Editor in question. 
+If a ZenIP editor leaves the organization which he or she represents, he or she will be automatically removed as ZenIP editor and the organization will nominate a replacement via ZenIP.
 
 #### ZenIP Editors Responsibilities and Workflow
 

--- a/zenip-42000.md
+++ b/zenip-42000.md
@@ -7,7 +7,7 @@
     Owners: Jonas Rubel, <jonas@zensystem.io>
     Discussions-To: <jonas@zensystem.io>
     Comments-URI: https://horizen.global/invite/discord
-    Status: Draft 
+    Status: Active 
     Type: Process
     Created: 2019-09-05
     License: MIT


### PR DESCRIPTION
Updating the list of Editors and the process for removing Editors should one resign from the organization he or she represents. This is to harmonize ZenIP-42000 with the changes approved via ZenIP-42001.