### PR TITLE
fix: engineering has agreed to keep the z_getnewaddress RPC endpoint.

### DIFF
--- a/zenip-42204.md
+++ b/zenip-42204.md
@@ -55,7 +55,7 @@ We propose to prevent shielding (t -> z) support at the consensus level (Mempool
     - rpcwallet.cpp `z_sendmany` enforce (fromTaddr = zaddr.IsValid();)
 4. The `z_mergetoaddress` accepts shielded and unshielded addresses as inputs to the from address argument, these will change to shielded addresses only.
     - rpcwallet.cpp z_mergetoaddress, remove any code not supporting the (address == "ANY_ZADDR") logic flow.
-5. Receiving transactions that include public inputs of transaction version -3 after the hard fork activation should increase a peers ban score.
+5. After the fork, transaction with version "-3" containing public inputs are allowed provided they do not move funds to the shielded pool (this can be checked by requiring vpub_old = 0 for each joinsplit) 
     - main.cpp ProcessMessage add check and increase ban score with Misbehaving(), also in main.cpp
 
 This change would activate on a hard fork at block X (Date TBD)

--- a/zenip-42204.md
+++ b/zenip-42204.md
@@ -51,14 +51,11 @@ We propose to prevent shielding (t -> z) support at the consensus level (Mempool
 2. Coinbase `z_shieldcoinbase` will be disabled.
     - (Client.cpp + server.cpp)  remove z_shieldcoinbase from CRPCConvertParam.
     - rpcwallet.cpp remove z_shieldcoinbase.
-3. Disable `z_getnewaddress` to prevent new zaddr’s from being created.
-    - rpcwallet.cpp remove z_getnewaddress method.
-    - Wallet.cpp remove GenerateNewZKey.
-4. RPC endpoint `z_sendmany` accepts shielded and unshielded addresses as inputs to the from address argument, these will change to shielded addresses only.
+3. RPC endpoint `z_sendmany` accepts shielded and unshielded addresses as inputs to the from address argument, these will change to shielded addresses only.
     - rpcwallet.cpp `z_sendmany` enforce (fromTaddr = zaddr.IsValid();)
-5. The `z_mergetoaddress` accepts shielded and unshielded addresses as inputs to the from address argument, these will change to shielded addresses only.
+4. The `z_mergetoaddress` accepts shielded and unshielded addresses as inputs to the from address argument, these will change to shielded addresses only.
     - rpcwallet.cpp z_mergetoaddress, remove any code not supporting the (address == "ANY_ZADDR") logic flow.
-6. Receiving transactions that include public inputs of transaction version -3 after the hard fork activation should increase a peers ban score.
+5. Receiving transactions that include public inputs of transaction version -3 after the hard fork activation should increase a peers ban score.
     - main.cpp ProcessMessage add check and increase ban score with Misbehaving(), also in main.cpp
 
 This change would activate on a hard fork at block X (Date TBD)


### PR DESCRIPTION
Reason - z-to-z transactions would still be feasible after its removal (z_sendmany change is always returned to from-address); so its removal would just make things harder for the z-features but does not prevent importing externally generated keys/addresses.